### PR TITLE
어떡해 벌써 5주차

### DIFF
--- a/Assets/Prefabs/Dongle.prefab
+++ b/Assets/Prefabs/Dongle.prefab
@@ -112,7 +112,7 @@ Rigidbody2D:
     serializedVersion: 2
     m_Bits: 0
   m_Interpolate: 1
-  m_SleepingMode: 1
+  m_SleepingMode: 0
   m_CollisionDetection: 0
   m_Constraints: 0
 --- !u!58 &3797729804181966465
@@ -162,8 +162,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b157e57b6ab37046b44aaa23ce719cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  manager: {fileID: 0}
+  effect: {fileID: 0}
   level: 0
   isDrag: 0
+  isMerge: 0
 --- !u!95 &2065715887953088024
 Animator:
   serializedVersion: 5

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,164 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &234260454
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 234260455}
+  - component: {fileID: 234260458}
+  - component: {fileID: 234260457}
+  - component: {fileID: 234260456}
+  m_Layer: 0
+  m_Name: Bottom (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &234260455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 234260454}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.14, y: 0.05, z: 0}
+  m_LocalScale: {x: 10, y: 5, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1280173660}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &234260456
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 234260454}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &234260457
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 234260454}
+  m_BodyType: 2
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!212 &234260458
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 234260454}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 311925a002f4447b3a28927169b83ea6, type: 3}
+  m_Color: {r: 0.254717, g: 0.1766198, b: 0.17254902, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &234477477
 GameObject:
   m_ObjectHideFlags: 0
@@ -219,7 +377,9 @@ MonoBehaviour:
   dongleGroup: {fileID: 396369925}
   effectPrefab: {fileID: 6620240152264022781, guid: ffecaa0f86c92244f80bd23823eab87b, type: 3}
   effectGroup: {fileID: 234477478}
+  score: 0
   maxLevel: 0
+  isOver: 0
 --- !u!4 &485103479
 Transform:
   m_ObjectHideFlags: 0
@@ -742,6 +902,7 @@ Transform:
   m_Children:
   - {fileID: 1791141079}
   - {fileID: 1235152001}
+  - {fileID: 234260455}
   - {fileID: 791971261}
   - {fileID: 1778619784}
   - {fileID: 1887742002}
@@ -1225,7 +1386,7 @@ GameObject:
   - component: {fileID: 1887742003}
   m_Layer: 0
   m_Name: Line
-  m_TagString: Untagged
+  m_TagString: Finish
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1332,7 +1493,7 @@ SpriteRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f341eb92f5cc98a49bfebb13344a57aa, type: 3}
-  m_Color: {r: 0.9056604, g: 0.20932718, b: 0.20932718, a: 1}
+  m_Color: {r: 0.90588236, g: 0.64649385, b: 0.20784314, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0

--- a/Assets/Scripts/Dongle.cs
+++ b/Assets/Scripts/Dongle.cs
@@ -10,15 +10,18 @@ public class Dongle : MonoBehaviour
     public bool isDrag;
     public bool isMerge;
 
-    Rigidbody2D rigid;
+    public Rigidbody2D rigid;
     CircleCollider2D circle;
     Animator anim;
+    SpriteRenderer spriteRenderer;
 
+    float deadTime;
     private void Awake()
     {
         rigid = GetComponent<Rigidbody2D>();
         circle = GetComponent<CircleCollider2D>();
         anim = GetComponent<Animator>();
+        spriteRenderer = GetComponent<SpriteRenderer>();
     }
 
     void OnEnable()
@@ -90,6 +93,10 @@ public class Dongle : MonoBehaviour
         rigid.simulated = false;
         circle.enabled = false;
 
+        if(targetPos == Vector3.up * 100)
+        {
+            EffectPlay();
+        }
         StartCoroutine(HideRoutine(targetPos));
     }
 
@@ -100,10 +107,18 @@ public class Dongle : MonoBehaviour
         while(frameCount < 20)
         {
             frameCount++;
-            transform.position = Vector3.Lerp(transform.position, targetPos, 0.5f);
+            if(targetPos != Vector3.up * 100)
+            {
+                transform.position = Vector3.Lerp(transform.position, targetPos, 0.5f);
+            }
+            else if(targetPos == Vector3.up * 100)
+            {
+                transform.localScale = Vector3.Lerp(transform.localScale, Vector3.zero, 0.2f);
+            }
             yield return null;
         }
 
+        manager.score += (int)Mathf.Pow(2, level);
         isMerge = false;
         gameObject.SetActive(false);
     }
@@ -133,6 +148,31 @@ public class Dongle : MonoBehaviour
         isMerge = false;
     }
 
+    private void OnTriggerStay2D(Collider2D collision)
+    {
+        if(collision.tag == "Finish")
+        {
+            deadTime += Time.deltaTime;
+
+            if(deadTime > 2)
+            {
+                spriteRenderer.color = new Color(0.9f,0.2f,0.2f);
+            }
+            if(deadTime > 5)
+            {
+                manager.GameOver();
+            }
+        }
+    }
+
+    private void OnTriggerExit2D(Collider2D collision)
+    {
+        if(collision.tag == "Finish")
+        {
+            deadTime = 0;
+            spriteRenderer.color = Color.white;
+        }
+    }
     void EffectPlay()
     {
         effect.transform.position = transform.position;

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,7 +10,9 @@ public class GameManager : MonoBehaviour
     public GameObject effectPrefab;
     public Transform effectGroup;
 
+    public int score;
     public int maxLevel;
+    public bool isOver;
     void Awake()
     {
         Application.targetFrameRate = 60;
@@ -34,6 +36,10 @@ public class GameManager : MonoBehaviour
     }
     void NextDongle()
     {
+        if(isOver)
+        {
+            return;
+        }
         Dongle newDongle = GetDongle();
         lastDongle = newDongle;
         lastDongle.manager = this;
@@ -71,5 +77,33 @@ public class GameManager : MonoBehaviour
         lastDongle = null;
     }
 
+    public void GameOver()
+    {
+        if (isOver)
+        {
+            return;
+        }
 
+        isOver = true;
+
+        StartCoroutine("GameOverRoutine");
+    }
+
+    IEnumerator GameOverRoutine()
+    {
+        //1.장면 안에 활성화 되어있는 모든 동글 가져오기
+        Dongle[] dongles = FindObjectsOfType<Dongle>();
+
+        //2. 지우기 전에 모든 동글의 물리효과 비활성화
+        for (int index = 0; index < dongles.Length; index++)
+        {
+            dongles[index].rigid.simulated = false;
+        }
+        //3. 1번의 목록을 하나씩 접근해서 지우기
+        for (int index = 0; index < dongles.Length; index++)
+        {
+            dongles[index].Hide(Vector3.up * 100);
+            yield return new WaitForSeconds(0.1f);
+        }
+    }
 }


### PR DESCRIPTION
# 개요
골드메탈의 물리 퍼즐게임 - 게임오버 구현하기 [유니티 기초 강좌 B58]을 듣고 따라 만들었습니다.

# 배운 점
mathf.pow(n,m)==n의 m제곱이고, float형태라서 정수 형태로 써야할 때 앞에 (int)를 붙이면 된다는 것.

게임오버를 한 번만 출력하려고 동글이 5초동안 닿아있을 때 실행되는 게임 오버 함수 안에 isOver를 True로 만드는 것과 isOver가 True면 함수를 바로 종료시키는(그냥 return만 하는) 코드를 넣는 것 신기, 나였다면 어떻게 할까 싶었는데 결국 다듬으면서 return까지는 썼을 거 같은데 True가 아니라 1이나 0등을 넣고 비슷하게 if isOver==0 : return이런식으로 했었을 것 같다. 생각해보니 True의 사용법을 아직 배운 적이 없었던 것 같다. 파이썬에서 True랑 False가 0이나 1의 값이라는 것만 배웠는데 아직 뭐가 뭔지도 안 익혀놨었던 게 생각이 나서 유니티 하다말고 잠시 파이썬 복습도 했다.ㅋㅋ-True는 1 False가 0이고, while 1: == while True 마찬가지로 0==False 취급해서 사용이 된다(+while False이면 반복문이 실행되지 않는다)
-게임오버 출력 후에 다음 동글을 생성 및 드랍시키지 않으려고 또 사용

for문 안에 콤마 대신에 세미콜론을 쓰는 듯해 보이고, index<dongle.Length가 끝값으로 지정된 것이 신기했는데, 아직 리스트와 for문을 다 못배워서 처음 본 건지 c##에서 쓰는 거라 처음 보는 건지 궁금하다

코루틴은 문자열로 호출해도 된다는 점.

게임오버 될 때 모든 동글을 지울 때에, 물리효과를 비활성화 시키는 것과 동글을 하나씩 지우는 것의 for문을 똑같이 쓰지만 각각 따로 실행시켜야 하는 것. 순간적으로 왜 따로썼나 생각이 들었는데, 다시 생각해보니 물리효과를 비활성화 시키는 이유부터가 동글들이 지워질 때에 레벨업 하는 것을 막기 위함인데 "동글 하나를 비활성화-지우기 다음 동글을 비활성화-지우기..."순으로 실행이 되면 동글이 레벨업 하는 것을 막는 알고리즘으로 보긴 힘들기 때문인 것이다.

# 어려웠던 점
동글을 neversleep상태로 해도 동글이 빨간색으로 안 바뀌고, 콘솔에 게임오버도 안 뜨는 현상 발생, 라인의 tag가 finish인 거도 확인하고, 위치도 라인의 z값과 동글 그룹의 z값이 같고 라인의 y값 6, 동글 그룹의 y값 7에서 -1.4정도 되는 동글들이 라인에 닿고 있는 게 보이고, 씬에서 3D로 바꿔서 봐도 한 평면상에 존재하는데 안됨...일단 진행하다가 게임오버 한 번만 출력하기 위해서 동글의 스크립트 안에 collision.tag="Finish"를 써넣을때에 설마 싶었는데 F를 f로 잘못적어서 난 오류였던 것...이후 동글이 빨갛게 변하는 것, 게임오버가(한 번만)출력되는 것까지 정상작동. 오타 이외에 실수는 안 한것에 안심했다


# 참고 자료
물리 퍼즐게임 - 게임오버 구현하기 [유니티 기초 강좌 B58]
https://www.youtube.com/watch?v=p-gsoqgn8C8
