### PR TITLE
종강총회를 하고 난 7주차

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -342,11 +342,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b01531256bb8764fa41a42cff8c11e7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  lastDongle: {fileID: 0}
   donglePrefab: {fileID: 8700868910742405447, guid: 4aca2627a1b170c44b93c329211c7894, type: 3}
   dongleGroup: {fileID: 396369925}
+  donglePool: []
   effectPrefab: {fileID: 6620240152264022781, guid: ffecaa0f86c92244f80bd23823eab87b, type: 3}
   effectGroup: {fileID: 234477478}
+  effectPool: []
+  poolSize: 3
+  poolCursor: 0
+  lastDongle: {fileID: 0}
   bgmPlayer: {fileID: 1957987079}
   sfxPlayer:
   - {fileID: 646408818}

--- a/Assets/Scripts/Dongle.cs
+++ b/Assets/Scripts/Dongle.cs
@@ -29,6 +29,26 @@ public class Dongle : MonoBehaviour
     {
         anim.SetInteger("Level", level);
     }
+
+    void OnDisable()
+    {
+        //동글 속성 초기화
+        level = 0;
+        isDrag = false;
+        isMerge = false;
+        isAttach = false;
+
+        //동글 트랜스폼 초기화
+        transform.localPosition = Vector3.zero;
+        transform.localRotation = Quaternion.identity;
+        transform.localScale = Vector3.one;
+
+        //동글 물리 초기화
+        rigid.simulated = false;
+        rigid.velocity = Vector2.zero;
+        rigid.angularVelocity = 0;
+        circle.enabled = true;
+    }
     void Update()
     {
         

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -4,11 +4,17 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
-    public Dongle lastDongle;
+    
     public GameObject donglePrefab;
     public Transform dongleGroup;
+    public List<Dongle> donglePool;
     public GameObject effectPrefab;
     public Transform effectGroup;
+    public List<ParticleSystem> effectPool;
+    [Range(1, 30)]
+    public int poolSize;
+    public int poolCursor;
+    public Dongle lastDongle;
 
     public AudioSource bgmPlayer;
     public AudioSource[] sfxPlayer;
@@ -22,6 +28,14 @@ public class GameManager : MonoBehaviour
     void Awake()
     {
         Application.targetFrameRate = 60;
+
+        donglePool = new List<Dongle>();
+        effectPool = new List<ParticleSystem>();
+        for(int index=0; index < poolSize; index++)
+        {
+            MakeDongle();
+        }
+
     }
     // Start is called before the first frame update
     void Start()
@@ -30,26 +44,41 @@ public class GameManager : MonoBehaviour
         NextDongle();
     }
 
-    Dongle GetDongle()
+    Dongle MakeDongle()
     {
         //이펙트생성
         GameObject instantEffectObj = Instantiate(effectPrefab, effectGroup);
+        instantEffectObj.name = "Effect" + effectPool.Count;
         ParticleSystem instantEffect = instantEffectObj.GetComponent<ParticleSystem>();
+        effectPool.Add(instantEffect);
+
         //동글생성
         GameObject instantDongleObj = Instantiate(donglePrefab, dongleGroup);
+        instantDongleObj.name = "Dongle" + donglePool.Count;
         Dongle instantDongle = instantDongleObj.GetComponent<Dongle>();
+        instantDongle.manager = this;
         instantDongle.effect = instantEffect;
+        donglePool.Add(instantDongle);
+
         return instantDongle;
+    }
+    Dongle GetDongle()
+    {
+        for(int index=0; index < donglePool.Count; index++) {
+            poolCursor = (poolCursor + 1) % donglePool.Count;
+            if (!donglePool[poolCursor].gameObject.activeSelf) {
+                return donglePool[poolCursor];
+            }
+        }
+        return MakeDongle();
     }
     void NextDongle()
     {
-        if(isOver)
-        {
+        if(isOver)  {
             return;
         }
-        Dongle newDongle = GetDongle();
-        lastDongle = newDongle;
-        lastDongle.manager = this;
+
+        lastDongle = GetDongle();
         lastDongle.level = Random.Range(0, maxLevel);
         lastDongle.gameObject.SetActive(true);
 


### PR DESCRIPTION
# 개요
골드메탈의 물리 퍼즐게임 - 쉽게 구현해보는 오브젝트풀링 [유니티 기초 강좌 B60]을 듣고 따라 만들었습니다.

# 주저리
강의 초반에 오브젝트풀링의 설명을 듣다보니 오브젝트를 미리 많이 만들어 놓고 가져다 쓰는 것이라면, 오브젝트를 몇개 만들어 놓고, 그 오브젝트를 거의 다 써갈 때 쯤(하나, 두개 정도 남았을 때) 그 오브젝트를 더 만드는 방법일까 하는 생각이 들었는데, 

내가 제대로 이해한 건진 모르겠지만 이번에 작성한 코드는 미리 정해 놓은 만큼 오브젝트를 만들고, 오브젝트를 '다 썼다면'새 오브젝트를 생성 하는 방법인 거 같은데, 이렇게 해도 꽤나 자연스럽게 실행이 되는 걸 보아하니 내가 생각한 방법은 언제 어울릴 지, 아니면 이번 방법이 그냥 최선인지 궁금해졌다.

# 배운 점
게임매니저의 스크립트에서 맨 위에서 'public list<> ~~풀'이라고 선언 한 것과는 반대로 awake에서 초기화 해 줄때는 '~~풀 = new List<>()'이라고 하는 것

함수의 리턴 값으로 리턴 값이 있는 함수를 사용할 수 있다(이번엔 instantDongle을 리턴하는 MakeDongle함수를 리턴값으로 사용)

오브젝트의 값을 초기화 할 때 각도는 transform.(local)Rotation=Quaternion.identity; 하면 0이 된다

ondisabled는 비활성화할 때 자동으로 실행되기에, 따로 호출할 필요는 없다


# 어려웠던 점
오랜만에 테스트할 때 오류발생, 디버깅;
-첫 테스트 때 노래가 안 나오고, for문 안에 poolCursor를 더해주는 코드에서 poolCursor에 빨간 줄이 그어져 있어도 영상 속 코드랑 같고 실행은 되어서 일단 넘겼는데, 이는 맨 위에서 풀커서를 선언할 때부터, for 문 안에 첫 poolCursor이외에 전부 오타를 내서...오타를 낸 걸 고치니 다 정상이 됐고,
두 번째 테스트 때는 아예 실행이 안 되는 컴파일러 에러가 떴는데, 이전에 Dongle newDongle = GetDongle();  lastDongle = newDongle;로 새 동글을 만드는 과정에서 2줄로 했던 걸 lastDongle = GetDongle();로 1줄로 줄이는 과정에서 괄호를 빼먹어서 오류가 발생했다.


# 참고 자료
물리 퍼즐게임 - 쉽게 구현해보는 오브젝트풀링 [유니티 기초 강좌 B60]
https://www.youtube.com/watch?v=uFAYFoaEwhk&list=PLO-mt5Iu5TeajtA5UQT7_2UjB7_dkGagU&index=8
